### PR TITLE
Adds -webkit-backdrop-filter property for Safari

### DIFF
--- a/src/base-styles.ts
+++ b/src/base-styles.ts
@@ -68,6 +68,7 @@ export const baseStyles = css`
     background: var(--ninja-overflow-background);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    -webkit-backdrop-filter: var(--ninja-backdrop-filter);
     backdrop-filter: var(--ninja-backdrop-filter);
     text-align: left;
     color: var(--ninja-text-color);


### PR DESCRIPTION
This PR adds support for backdrop-filter property on Safari. According to [this document](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter), backdrop-filter property is not compatible with Safari. It requires a vendor prefix `-webkit-backdrop-filter`