### PR TITLE
Clean up hotkeys on disconnect

### DIFF
--- a/src/ninja-keys.ts
+++ b/src/ninja-keys.ts
@@ -184,6 +184,11 @@ export class NinjaKeys extends LitElement {
     this._registerInternalHotkeys();
   }
 
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unregisterInternalHotkeys();
+  }
+
   private _flattern(members: INinjaAction[], parent?: string): INinjaAction[] {
     let children = [] as Array<any>;
     if (!members) {
@@ -296,6 +301,33 @@ export class NinjaKeys extends LitElement {
       });
     }
   }
+
+  private _unregisterInternalHotkeys() {
+    if (this.openHotkey) {
+      hotkeys.unbind(this.openHotkey)
+    }
+
+    if (this.selectHotkey) {
+      hotkeys.unbind(this.selectHotkey)
+    }
+
+    if (this.goBackHotkey) {
+      hotkeys.unbind(this.goBackHotkey)
+    }
+
+    if (this.navigationDownHotkey) {
+      hotkeys.unbind(this.navigationDownHotkey)
+    }
+
+    if (this.navigationUpHotkey) {
+      hotkeys.unbind(this.navigationUpHotkey)
+    }
+
+    if (this.closeHotkey) {
+      hotkeys.unbind(this.closeHotkey)
+    }
+  }
+
 
   private _actionFocused(index: INinjaAction, $event: MouseEvent) {
     // this.selectedIndex = index;


### PR DESCRIPTION
This makes ninja-keys compatible with [Turbo](https://turbo.hotwired.dev/) for Rails apps and other JS frameworks that work similarly. It should clean up the hotkeys on disconnect so when it reconnects it can configure hotkeys to the new element.