### PR TITLE
fix: rendering for multiple key options

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -102,7 +102,7 @@
       {
         id: 'Search Projects',
         title: 'Search projects...',
-        hotkey: 'Shift+N',
+        hotkey: 'Shift+N,Shift+S',
         icon: `<svg xmlns="http://www.w3.org/2000/svg" class="ninja-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
 </svg>`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "ninja-keys",
-  "version": "1.1.6",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.6",
+      "name": "ninja-keys",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@material/mwc-icon": "0.25.3",
         "hotkeys-js": "3.8.7",
-        "lit": "2.0.2"
+        "lit": "2.2.6"
       },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.5.3",
@@ -255,9 +256,9 @@
       "dev": true
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
-      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
+      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
     },
     "node_modules/@material/mwc-icon": {
       "version": "0.25.3",
@@ -4429,14 +4430,13 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
-      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
-      "license": "BSD-3-Clause",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.6.tgz",
+      "integrity": "sha512-K2vkeGABfSJSfkhqHy86ujchJs3NR9nW1bEEiV+bXDkbiQ60Tv5GUausYN2mXigZn8lC1qXuc46ArQRKYmumZw==",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-element": "^3.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       }
     },
     "node_modules/lit-analyzer": {
@@ -4706,18 +4706,18 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
-      "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
-      "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
+      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -7968,9 +7968,9 @@
       "dev": true
     },
     "@lit/reactive-element": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
-      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
+      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
     },
     "@material/mwc-icon": {
       "version": "0.25.3",
@@ -11269,13 +11269,13 @@
       "dev": true
     },
     "lit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
-      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.6.tgz",
+      "integrity": "sha512-K2vkeGABfSJSfkhqHy86ujchJs3NR9nW1bEEiV+bXDkbiQ60Tv5GUausYN2mXigZn8lC1qXuc46ArQRKYmumZw==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-element": "^3.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       }
     },
     "lit-analyzer": {
@@ -11502,18 +11502,18 @@
       }
     },
     "lit-element": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
-      "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
       }
     },
     "lit-html": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
-      "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
+      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@material/mwc-icon": "0.25.3",
     "hotkeys-js": "3.8.7",
-    "lit": "2.0.2"
+    "lit": "2.2.6"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.5.3",

--- a/src/ninja-action.ts
+++ b/src/ninja-action.ts
@@ -1,11 +1,11 @@
-import {LitElement, html, css, } from 'lit';
+import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {join} from 'lit/directives/join.js';
 import '@material/mwc-icon';
 
 import {INinjaAction} from './interfaces/ininja-action.js';
-
 
 @customElement('ninja-action')
 export class NinjaAction extends LitElement {
@@ -54,11 +54,14 @@ export class NinjaAction extends LitElement {
       text-overflow: ellipsis;
     }
     .ninja-hotkeys {
-      margin-left: 0.5em;
       flex-shrink: 0;
       width: min-content;
+      display: flex;
     }
 
+    .ninja-hotkeys kbd {
+      font-family: inherit;
+    }
     .ninja-hotkey {
       background: var(--ninja-secondary-background-color);
       padding: 0.06em 0.25em;
@@ -66,7 +69,14 @@ export class NinjaAction extends LitElement {
       text-transform: capitalize;
       color: var(--ninja-secondary-text-color);
       font-size: 0.75em;
+      font-family: inherit;
+    }
+
+    .ninja-hotkey + .ninja-hotkey {
       margin-left: 0.5em;
+    }
+    .ninja-hotkeys + .ninja-hotkeys {
+      margin-left: 1em;
     }
   `;
 
@@ -80,7 +90,7 @@ export class NinjaAction extends LitElement {
    * Display hotkey as separate buttons on UI or as is
    */
   @property({type: Boolean})
-  hotKeysJoinedView = false;
+  hotKeysJoinedView = true;
 
   /**
    * Scroll to show element
@@ -114,9 +124,11 @@ export class NinjaAction extends LitElement {
 
   override render() {
     let icon;
-    if (this.action.mdIcon){
-      icon = html`<mwc-icon part="ninja-icon" class="ninja-icon">${this.action.mdIcon}</mwc-icon>`
-    } else if (this.action.icon){
+    if (this.action.mdIcon) {
+      icon = html`<mwc-icon part="ninja-icon" class="ninja-icon"
+        >${this.action.mdIcon}</mwc-icon
+      >`;
+    } else if (this.action.icon) {
       icon = unsafeHTML(this.action.icon || '');
     }
 
@@ -126,11 +138,25 @@ export class NinjaAction extends LitElement {
     let hotkey;
     if (this.action.hotkey) {
       if (this.hotKeysJoinedView) {
-        hotkey = html`<div class="ninja-hotkey">${this.action.hotkey}</div>`;
+        hotkey = this.action.hotkey.split(',').map((hotkeys) => {
+          const keys = hotkeys.split('+');
+          const joinedKeys = html`${join(
+            keys.map((key) => html`<kbd>${key}</kbd>`),
+            '+'
+          )}`;
+
+          return html`<div class="ninja-hotkey ninja-hotkeys">
+            ${joinedKeys}
+          </div>`;
+        });
       } else {
-        hotkey = this.action.hotkey
-          .split('+')
-          .map((key) => html`<div class="ninja-hotkey">${key}</div>`);
+        hotkey = this.action.hotkey.split(',').map((hotkeys) => {
+          const keys = hotkeys.split('+');
+          const keyElements = keys.map(
+            (key) => html`<kbd class="ninja-hotkey">${key}</kbd>`
+          );
+          return html`<kbd class="ninja-hotkeys">${keyElements}</kbd>`;
+        });
       }
     }
 
@@ -140,7 +166,11 @@ export class NinjaAction extends LitElement {
     };
 
     return html`
-      <div class="ninja-action" part="ninja-action ${this.selected ? 'ninja-selected' : ''}" class=${classMap(classes)}>
+      <div
+        class="ninja-action"
+        part="ninja-action ${this.selected ? 'ninja-selected' : ''}"
+        class=${classMap(classes)}
+      >
         ${icon}
         <div class="ninja-title">${this.action.title}</div>
         ${hotkey}


### PR DESCRIPTION
This also improves some a11y for the actual keys with the `<kbd>` element

(Also had to upgrade `lit` for the `join()`to work, which I think should have been supported by v 2.0.2)