### PR TITLE
Adds a guard clause for _inputRef

### DIFF
--- a/src/ninja-header.ts
+++ b/src/ninja-header.ts
@@ -121,7 +121,7 @@ export class NinjaHeader extends LitElement {
   }
 
   focusSearch() {
-    requestAnimationFrame(() => this._inputRef.value!.focus());
+    requestAnimationFrame(() => (this._inputRef && this._inputRef.value!.focus()));
   }
 
   private _handleInput(event: Event) {


### PR DESCRIPTION
Fixes #34

It seems in some browsers, this `requestAnimationFrame` will execute before the ref exists which throws errors around calling `.focus()` on undefined. 

![image](https://user-images.githubusercontent.com/2391/207693547-2d883e55-5283-4430-a7e0-9a184693830f.png)
